### PR TITLE
Allow numbers in enums as well as values of single char

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -317,10 +317,10 @@
                     "array_name": "schemas.enum",
                     "checks": [
                         {
-                            "check_array_pattern": "^[A-Z][A-Z_]*[A-Z]$",
+                            "check_array_pattern": "^[A-Z0-9][A-Z0-9_]*$",
                             "message": "enum property does not follow UPPER_SNAKE_CASE",
                             "name": "check_array_pattern",
-                            "value": "^[A-Z][A-Z_]*[A-Z]$",
+                            "value": "^[A-Z0-9][A-Z0-9_]*$",
                             "exceptions": [
                                 {
                                     "title": "Cart Masterdata API",
@@ -336,10 +336,10 @@
                     "array_name": "schemas.x-extensible-enum",
                     "checks": [
                         {
-                            "check_array_pattern": "^[A-Z][A-Z_]*[A-Z]$",
+                            "check_array_pattern": "^[A-Z0-9][A-Z0-9_]*$",
                             "message": "x-extensible-enum property does not follow UPPER_SNAKE_CASE",
                             "name": "check_array_pattern",
-                            "value": "^[A-Z][A-Z_]*[A-Z]$",
+                            "value": "^[A-Z0-9][A-Z0-9_]*$",
                             "exceptions": [
                                 {
                                     "title": "Cart Masterdata API",

--- a/tests/B111/B111_passing_test_schemas_enum.yaml
+++ b/tests/B111/B111_passing_test_schemas_enum.yaml
@@ -9,3 +9,6 @@ exmcjkbabzivqvzbksbuxlw:
               - XTTTH
               - GNS
               - QCVRUCNSTQMFGNY
+              - SOME_0
+              - 42
+              - E

--- a/tests/B111/B111_passing_test_schemas_x-extensible-enum.yaml
+++ b/tests/B111/B111_passing_test_schemas_x-extensible-enum.yaml
@@ -11,3 +11,6 @@ iqbyencvwfszdjwseyk:
                 - MRYWZAPQHDHP_HBCBNJM
                 - RD_UPZD
                 - GZZW
+                - SOME_0
+                - 42
+                - E


### PR DESCRIPTION
In our API, we have the following snippet:

```
components:
  schemas:
    OpeningHoursByWeekday:
      type: object
      properties:
        weekday:
          type: integer
          format: int32
          description: |
            defines the weekday of the opening hour entry as numerical (0 = SUN, 1 = MON)
          enum:
            - 0
            - 1
            - 2
            - 3
            - 4
            - 5
            - 6
```

I don't want to discuss here whether modelling as `0` or `SUN` or `SUNDAY` would be preferred, or if we could simply use `minimum` and `maximum` instead of `enum` (as it is perfectly valid according to OpenAPI standards). The example simply emphasises the need to allow numeric values as well.

This PR changes the regular expressions so that the following values are valid enums:
- `0`
- `SOME_0`,
- `E`

The single letter given in the last example was not matched by the former regular expressions. It will be valid by this PR as well.